### PR TITLE
Holding Stella type errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 Template for an implementation of Stella in Kotlin.
 
 ![Screenshot from Intellij IDEA.](images/idea-demo.png)
+
+## How to throw Stella type errors
+In `org.stella` exist simple `StellaTypeException`, which you should throw any time you encounter a type error. 
+### Improvements
+- [ ] Add more information to the exception, like the line number and the file name.
+- [ ] Add functionality in `StellaTypeException` for each type error.

--- a/src/main/kotlin/org/stella/StellaTypeException.kt
+++ b/src/main/kotlin/org/stella/StellaTypeException.kt
@@ -1,0 +1,8 @@
+package org.stella
+
+class StellaTypeException : Exception {
+    constructor() : super()
+    constructor(message: String?) : super(message)
+    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    constructor(cause: Throwable?) : super(cause)
+}

--- a/src/test/kotlin/org/stella/MainTest.kt
+++ b/src/test/kotlin/org/stella/MainTest.kt
@@ -11,6 +11,7 @@ const val wellTypedDir = "$baseDir/well-typed"
 const val illTypedDir = "$baseDir/ill-typed"
 
 internal class MainTest {
+
     @ParameterizedTest(name = "{index} Typechecking well-typed program {0}")
     @ValueSource(strings = [
         "$wellTypedDir/factorial.stella",
@@ -27,7 +28,11 @@ internal class MainTest {
         val original = System.`in`
         val fips = FileInputStream(File(filepath))
         System.setIn(fips)
-        main()
+        try {
+            main()
+        } catch (e: StellaTypeException) {
+            throw java.lang.Exception("expected the typechecker to pass!")
+        }
         System.setIn(original)
     }
 
@@ -61,12 +66,12 @@ internal class MainTest {
         var typecheckerFailed = false
         try {
             main()
-        } catch (e: java.lang.Exception) {
+        } catch (e: StellaTypeException) {
             typecheckerFailed = true
         }
         if (!typecheckerFailed) {
             throw java.lang.Exception("expected the typechecker to fail!")
-        }        // TODO: check that there is a type error actually, and not a problem with implementation
+        }
         System.setIn(original)
     }
 }


### PR DESCRIPTION
Instead of catching Runtime errors, we can use a custom class that should be thrown every time a visitor encounters a type error.

**Possible improvements:**

> Make a functional to identify a specific error